### PR TITLE
Add missing dependency on atlas_hardware_interface in pronto_translators

### DIFF
--- a/pronto-lcm-ros-translators/src/pronto_translators/CMakeLists.txt
+++ b/pronto-lcm-ros-translators/src/pronto_translators/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   rospy
   std_msgs
+  atlas_hardware_interface
 )
 
 ## System dependencies are found with CMake's conventions

--- a/pronto-lcm-ros-translators/src/pronto_translators/package.xml
+++ b/pronto-lcm-ros-translators/src/pronto_translators/package.xml
@@ -43,9 +43,11 @@
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>atlas_hardware_interface</build_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>std_msgs</run_depend>
+  <run_depend>atlas_hardware_interface</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
Does not build for me using catkin otherwise with the following compile error:
<pre>
[100%] Building CXX object pronto_translators/CMakeFiles/ros2lcm_tl.dir/src/ros2lcm_tl.cpp.o
Linking CXX executable /media/kohlbrecher/d13379a9-180b-4569-83e9-329f1c847bc7/vigir_repo/pronto-distro/pronto-lcm-ros-translators/devel/lib/pronto_translators/lcm2ros
[100%] Built target lcm2ros
/media/kohlbrecher/d13379a9-180b-4569-83e9-329f1c847bc7/vigir_repo/pronto-distro/pronto-lcm-ros-translators/src/pronto_translators/src/ros2lcm_tl.cpp:16:53: fatal error: atlas_hardware_interface/AtlasPrefilter.h: No such file or directory
 #include <atlas_hardware_interface/AtlasPrefilter.h>
                                                     ^
compilation terminated.
make[2]: *** [pronto_translators/CMakeFiles/ros2lcm.dir/src/ros2lcm.cpp.o] Error 1
make[1]: *** [pronto_translators/CMakeFiles/ros2lcm.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
make[2]: *** [pronto_translators/CMakeFiles/ros2lcm_tl.dir/src/ros2lcm_tl.cpp.o] Error 1
make[1]: *** [pronto_translators/CMakeFiles/ros2lcm_tl.dir/all] Error 2
make: *** [all] Error 2
Invoking "make -j8 -l8" failed
</pre>

The IHMC stuff also fails to compile, but I fixed that for the moment by commenting out both translator nodes in CMakeLists.txt.